### PR TITLE
Fix broken geolite db

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 This is a Scala library that reads the recent change feeds from
 [Wikimedia's IRC channels](https://meta.wikimedia.org/wiki/IRC/Channels#Raw_feeds).
 
+This service uses GeoLite2 data created by MaxMind, available from <a href="http://www.maxmind.com">maxmind.com</a>.
+
 Usage:
 
 ```scala

--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,7 @@ libraryDependencies ++= Seq(
   "org.apache.kafka" % "kafka-clients" % "2.2.0",
   "ch.qos.logback" % "logback-core" % "1.1.2",
   "ch.qos.logback" % "logback-classic" % "1.1.2",
-  "io.imply" %% "hostbook" % "0.1"
+  "io.imply" %% "hostbook" % "0.2"
 )
 
 lazy val root = project.in(file(".")).enablePlugins(JavaAppPackaging)


### PR DESCRIPTION
Update wikiticker to use 0.2 version of hostbook so that we can geo
lookup works in wikiticker.

Updated attribution to maxmind.